### PR TITLE
FIX: Settings are now saved after each job run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# Change Log
+# Cyotek Azure Container Echo Change Log
+
+## 2.0.1
+
+### Fixed
+
+* Now saves settings after each job execution, preventing the
+  last runtime from being lost
 
 ## 2.0
 

--- a/Cyotek.AzureContainerEcho.Client/ApplicationContext.cs
+++ b/Cyotek.AzureContainerEcho.Client/ApplicationContext.cs
@@ -1,7 +1,7 @@
 ﻿// Azure Container Echo
 // https://github.com/cyotek/Cyotek.AzureContainerEcho
 
-// Copyright © 2013-2021 Cyotek Ltd. All Rights Reserved.
+// Copyright © 2013-2023 Cyotek Ltd. All Rights Reserved.
 
 // Licensed under the MIT License. See LICENSE.txt for the full text.
 
@@ -137,13 +137,13 @@ namespace Cyotek.AzureContainerEcho.Client
       this.Log(string.Format("Task Complete: {0}", e.Task.Name));
 
       this.SetIcon();
+
+      this.SaveSettings();
     }
 
     private void JobManagerTaskExceptionHandler(object sender, ScheduledTaskExceptionEventArgs e)
     {
-      this.Log(string.Format("Task Failed: {0}\n{1}", e.Task.Name, e.Exception.Message));
-
-      this.TrayIcon.ShowBalloonTip(10000, e.Task.Name, e.Exception.GetBaseException().Message, ToolTipIcon.Error);
+      this.LogException(e.Task.Name, e.Exception);
     }
 
     private void JobManagerTaskStartedHandler(object sender, ScheduledTaskEventArgs e)
@@ -192,6 +192,13 @@ namespace Cyotek.AzureContainerEcho.Client
       _logWriter.Flush();
     }
 
+    private void LogException(string title, Exception ex)
+    {
+      this.Log(string.Format("Task Failed: {0}\n{1}", title, ex.Message));
+
+      this.TrayIcon.ShowBalloonTip(10000, title, ex.GetBaseException().Message, ToolTipIcon.Error);
+    }
+
     private void OpenLogContextMenuClickHandler(object sender, EventArgs e)
     {
       AboutPanel.OpenUrl(_logFileName);
@@ -207,7 +214,14 @@ namespace Cyotek.AzureContainerEcho.Client
 
     private void SaveSettings()
     {
-      Json.WriteFile(_settingsFileName, _jobManager.Settings, JsonOptions.WriteWhitespace);
+      try
+      {
+        Json.WriteFile(_settingsFileName, _jobManager.Settings, JsonOptions.WriteWhitespace);
+      }
+      catch (Exception ex)
+      {
+        this.LogException("Save failed", ex);
+      }
     }
 
     private void SetIcon()

--- a/Cyotek.AzureContainerEcho.Client/Properties/AssemblyInfo.cs
+++ b/Cyotek.AzureContainerEcho.Client/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿// Azure Container Echo
 // https://github.com/cyotek/Cyotek.AzureContainerEcho
 
-// Copyright © 2013-2021 Cyotek Ltd. All Rights Reserved.
+// Copyright © 2013-2023 Cyotek Ltd. All Rights Reserved.
 
 // Licensed under the MIT License. See LICENSE.txt for the full text.
 
@@ -17,12 +17,11 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Cyotek Ltd")]
 [assembly: AssemblyProduct("Azure Container Echo")]
-[assembly: AssemblyCopyright("Copyright © 2013-2021 Cyotek Ltd. All Rights Reserved.")]
+[assembly: AssemblyCopyright("Copyright © 2013-2023 Cyotek Ltd. All Rights Reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("6044379e-f1ee-4f65-8c6f-4e6392e0f56d")]
 [assembly: CLSCompliant(true)]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0")]
+[assembly: AssemblyFileVersion("2.0.1.0")]

--- a/Cyotek.AzureContainerEcho/Properties/AssemblyInfo.cs
+++ b/Cyotek.AzureContainerEcho/Properties/AssemblyInfo.cs
@@ -25,4 +25,3 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(true)]
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.0.0")]


### PR DESCRIPTION
This fixes an issue where the last run time was lost, meaning some jobs may have been doing too much work